### PR TITLE
win32 fixes

### DIFF
--- a/lib/PDF/WebKit.pm
+++ b/lib/PDF/WebKit.pm
@@ -42,7 +42,7 @@ sub BUILD {
     $self->_normalize_options($self->_find_options_in_meta),
   });
 
-  if (not -e $self->configuration->wkhtmltopdf) {
+  if (not -x $self->configuration->wkhtmltopdf) {
     my $msg = "No wkhtmltopdf executable found\n";
     $msg   .= ">> Please install wkhtmltopdf - https://github.com/jdpace/PDFKit/wiki/Installing-WKHTMLTOPDF";
     die $msg;

--- a/lib/PDF/WebKit/Configuration.pm
+++ b/lib/PDF/WebKit/Configuration.pm
@@ -27,7 +27,8 @@ around 'BUILDARGS' => sub {
 
 sub _find_wkhtmltopdf {
   my $self = shift;
-  my $found = `which wkhtmltopdf`;
+  my $which = $^O eq "MSWin32" ? "where" : "which";
+  my $found = `$which wkhtmltopdf`;
   if ($? == 0) {
     chomp($found);
     return $found;

--- a/t/fixtures/mock_wkhtmltopdf.bat
+++ b/t/fixtures/mock_wkhtmltopdf.bat
@@ -1,0 +1,1 @@
+@%COMSPEC% /C exit 1 >nul

--- a/t/pdf-webkit-integration.t
+++ b/t/pdf-webkit-integration.t
@@ -85,7 +85,7 @@ describe "PDF::WebKit" => sub {
 
     it "should not allow shell injection in options" => sub {
       my $pdfkit = PDF::WebKit->new(\'html', header_center => "a title\"; touch $test_path #");
-      $pdfkit->to_pdf;
+      eval { $pdfkit->to_pdf }; # wkhtmltopdf itself errors out on windows
       ok(! -e $test_path);
     };
   };

--- a/t/pdf-webkit.t
+++ b/t/pdf-webkit.t
@@ -9,7 +9,8 @@ use File::Spec;
 BEGIN { require File::Spec->catfile(dirname(__FILE__), "spec_helper.pl") }
 
 # has to exist
-my $wkhtmltopdf = File::Spec->catfile($SPEC_ROOT,'fixtures','mock_wkhtmltopdf');
+my $ext = $^O eq "MSWin32" ? ".bat" : "";
+my $wkhtmltopdf = File::Spec->catfile($SPEC_ROOT,'fixtures',"mock_wkhtmltopdf$ext");
 
 describe "PDF::WebKit" => sub {
 


### PR DESCRIPTION
Here's a bunch of win32 fixes on top of TBSliver's -x consistency fix:

- instead of the *nix-specific which (which returns useless data on systems with cygwin), use where, which is on all windows systems
- fix for the shell injection test, which crashes with a "can't read website error" when using a real wkhtmltopdf
- fix for the test with a mock wkhtmltopdf, as the shell script provided is not executable on windows