### PR TITLE
Support args with multiple values

### DIFF
--- a/lib/PDF/WebKit.pm
+++ b/lib/PDF/WebKit.pm
@@ -194,7 +194,7 @@ sub _prepare_options {
       push @args, $name;
     }
     else {
-      push @args, $name, $val;
+      push @args, $name, (ref($val) eq 'ARRAY') ? @$val : $val;
     }
   }
   return @args;
@@ -271,6 +271,9 @@ C<< PDF::WebKit->configure >> class method:
     $_->meta_tag_prefix('my-prefix-');
 
     $_->default_options->{'--orientation'} = 'Portrait';
+
+    # Some options expects multiple values
+    $_->default_options->{'--custom-header'} = ['DNT', '1'];
   });
 
 See the L<new|/Constructor> method for the standard default options.

--- a/t/pdf-webkit.t
+++ b/t/pdf-webkit.t
@@ -107,7 +107,7 @@ describe "PDF::WebKit" => sub {
     };
 
     it "should accept multiple values" => sub {
-	  my $pdfkit = PDF::WebKit->new(\'html', '--custom-header' => [ 'X-Foo', 'bar bas' ] );
+      my $pdfkit = PDF::WebKit->new(\'html', '--custom-header' => [ 'X-Foo', 'bar bas' ] );
       my @command = $pdfkit->command;
       is( $command[index_of('--custom-header',@command) + 1], 'X-Foo' );
       is( $command[index_of('--custom-header',@command) + 2], 'bar bas' );

--- a/t/pdf-webkit.t
+++ b/t/pdf-webkit.t
@@ -106,6 +106,13 @@ describe "PDF::WebKit" => sub {
       like( $command[index_of('--no-collate',@command) + 1], qr/^-/ );
     };
 
+    it "should accept multiple values" => sub {
+	  my $pdfkit = PDF::WebKit->new(\'html', '--custom-header' => [ 'X-Foo', 'bar bas' ] );
+      my @command = $pdfkit->command;
+      is( $command[index_of('--custom-header',@command) + 1], 'X-Foo' );
+      is( $command[index_of('--custom-header',@command) + 2], 'bar bas' );
+    };
+
     it "should encapsulate string arguments in quotes" => sub {
       my $pdfkit = PDF::WebKit->new(\'html', header_center => "foo [page]");
       my @command = $pdfkit->command;


### PR DESCRIPTION
Some of the command line arguments supported by wkhtmltopdf requires
more than one value (like --cookie and --custom-header). This patch allow
users to specify multiple values by passing a array-ref.