### PR TITLE
Support multiple args and key value pair args

### DIFF
--- a/lib/PDF/WebKit.pm
+++ b/lib/PDF/WebKit.pm
@@ -189,12 +189,21 @@ sub _prepare_options {
   my $options = $self->options;
   my @args;
   while (my ($name,$val) = each %$options) {
-    next unless defined($val) && length($val);
-    if (lc($val) eq 'yes') {
-      push @args, $name;
-    }
-    else {
-      push @args, $name, $val;
+    next unless defined($val);
+
+    my $items = (ref $val ne 'ARRAY') ? [$val]: $val;
+    foreach my $item ( @{$items} ) {
+      if ( ref $item eq 'HASH' ) {
+        push @args, $name, each %{$item};
+      }
+      elsif ( length($item) ) {
+        if (lc($item) eq 'yes') {
+          push @args, $name;
+        }
+        else {
+          push @args, $name, $item;  
+        }
+      }
     }
   }
   return @args;
@@ -271,6 +280,15 @@ C<< PDF::WebKit->configure >> class method:
     $_->meta_tag_prefix('my-prefix-');
 
     $_->default_options->{'--orientation'} = 'Portrait';
+
+    # Some options expects multiple values
+    $_->default_options->{'--allow'} = ['/path/one', '/path/one'];
+
+    # Some options expects key value pairs
+    $_->default_options->{'--custom-header'} = {'DNT' => '1'};
+
+    # Some options allow multiple key value pairs
+    $_->default_options->{'--cookie'} = [ {'X-Foo' => 'foo'}, {'X-Bar' => 'bar'} ];
   });
 
 See the L<new|/Constructor> method for the standard default options.

--- a/t/pdf-webkit.t
+++ b/t/pdf-webkit.t
@@ -106,6 +106,33 @@ describe "PDF::WebKit" => sub {
       like( $command[index_of('--no-collate',@command) + 1], qr/^-/ );
     };
 
+    it "should accept key value pairs" => sub {
+      my $pdfkit = PDF::WebKit->new(\'html', '--custom-header' => { 'X-Foo', 'bar bas' } );
+      my @command = $pdfkit->command;
+      is( $command[index_of('--custom-header',@command) + 1], 'X-Foo' );
+      is( $command[index_of('--custom-header',@command) + 2], 'bar bas' );
+    };
+
+    it "should accept multiple values" => sub {
+      my $pdfkit = PDF::WebKit->new(\'html', '--allow' => [ '/path/one', '/path/two' ] );
+      my @command = $pdfkit->command;
+      my $index = index_of('--allow',@command);
+      is( $command[$index + 1], '/path/one' );
+      $index++;
+      is( $command[index_of('--allow',@command,$index) + 1], '/path/two' );
+    };
+
+    it "should accept multiple key value pairs" => sub {
+      my $pdfkit = PDF::WebKit->new(\'html', '--cookie' => [ {'X-Foo' => 'foo'}, {'X-Bar' => 'bar'} ] );
+      my @command = $pdfkit->command;
+      my $index = index_of('--cookie',@command);
+      is( $command[$index + 1], 'X-Foo' );
+      is( $command[$index + 2], 'foo' );
+      $index++;
+      is( $command[index_of('--cookie',@command, $index) + 1], 'X-Bar' );
+      is( $command[index_of('--cookie',@command, $index) + 2], 'bar' );
+    };
+
     it "should encapsulate string arguments in quotes" => sub {
       my $pdfkit = PDF::WebKit->new(\'html', header_center => "foo [page]");
       my @command = $pdfkit->command;

--- a/t/spec_helper.pl
+++ b/t/spec_helper.pl
@@ -7,9 +7,10 @@ unshift @INC, File::Spec->catfile($SPEC_ROOT,"..","lib");
 
 require PDF::WebKit;
 
-sub index_of ($\@) {
-  my ($what,$array) = @_;
-  for (my $i = 0; $i < @$array; $i++) {
+sub index_of ($\@;$) {
+  my ($what,$array,$position) = @_;
+  $position ||= 0;
+  for (my $i = $position; $i < @$array; $i++) {
     return $i if $array->[$i] eq $what;
   }
   return undef;


### PR DESCRIPTION
Some of the command line arguments supported by wkhtmltopdf could
be used multiple times (--allow or --cookie) also some arguments
require key-value syntax (--cookie and --custom-header).
This patch allow users to use argument multiple times by passing
an array-ref with values. Also you could provide hash-ref for
key-value arguments.